### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/src/main/java/com/frre/library/Generador.java
+++ b/src/main/java/com/frre/library/Generador.java
@@ -15,7 +15,7 @@ import java.util.Random;
  */
 public class Generador {
     
-    static Random rnd = new Random();
+    private static Random rnd = new Random();
     
     public static String generarApellidoAleatorio(){
         String appelidos = DataSource.apellidos;

--- a/src/main/java/com/frre/practica/isi/algoritmos/archivos/Alumno.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/archivos/Alumno.java
@@ -9,13 +9,13 @@ public class Alumno {
 
 
     @Clave
-    int legajo;
+    private int legajo;
 
     @Clave
-    String nomYApell;
+    private String nomYApell;
 
-    int dni;
-    double promedio;
+    private int dni;
+    private double promedio;
 
     public int getLegajo() {
         return legajo;

--- a/src/main/java/com/frre/practica/isi/algoritmos/archivos/Auto.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/archivos/Auto.java
@@ -8,10 +8,10 @@ import com.frre.library.Clave;
 public class Auto {
 
     @Clave
-    String localidad;
-    String patente;
-    String propietario;
-    int modelo;
+    private String localidad;
+    private String patente;
+    private String propietario;
+    private int modelo;
 
     @Override
     public String toString() {

--- a/src/main/java/com/frre/practica/isi/algoritmos/archivos/Cliente.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/archivos/Cliente.java
@@ -10,10 +10,10 @@ public class Cliente {
 
 
     @Clave
-    int legajo;
-    String nombre;
-    Fecha fecha;
-    double importe;
+    private int legajo;
+    private String nombre;
+    private Fecha fecha;
+    private double importe;
 
     @Override
     public String toString() {

--- a/src/main/java/com/frre/practica/isi/algoritmos/archivos/Usuario.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/archivos/Usuario.java
@@ -8,11 +8,11 @@ import com.frre.library.Clave;
 public class Usuario {
 
     @Clave
-    String domicilio;
+    private String domicilio;
     @Clave
-    int dni;
-    String nombre;
-    int edad;
+    private int dni;
+    private String nombre;
+    private int edad;
 
 
     public int getDni() {

--- a/src/main/java/com/frre/practica/isi/algoritmos/archivos/corte/Main.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/archivos/corte/Main.java
@@ -14,16 +14,16 @@ public class Main {
     //ambiente
 
     //acumuladores
-    static String resguardoSucursal;
-    static String resguardoPcia;
+    private static String resguardoSucursal;
+    private static String resguardoPcia;
 
     //registros
-    static Empleado registro;
+    private static Empleado registro;
 
     //acums
-    static double acumSucursal;
-    static double acumTotal;
-    static double acumPcia;
+    private static double acumSucursal;
+    private static double acumTotal;
+    private static double acumPcia;
 
     //archivo
     private static File archivo;

--- a/src/main/java/com/frre/practica/isi/algoritmos/archivos/indexados/Main.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/archivos/indexados/Main.java
@@ -15,16 +15,16 @@ public class Main {
     //ambiente
 
     //acumuladores
-    static String resguardoSucursal;
-    static String resguardoPcia;
+    private static String resguardoSucursal;
+    private static String resguardoPcia;
 
     //registros
-    static Empleado registro;
+    private static Empleado registro;
 
     //acums
-    static double acumSucursal;
-    static double acumTotal;
-    static double acumPcia;
+    private static double acumSucursal;
+    private static double acumTotal;
+    private static double acumPcia;
 
     //archivo
     private static File archivo;

--- a/src/main/java/com/frre/practica/isi/algoritmos/archivos/mezcla/Main.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/archivos/mezcla/Main.java
@@ -18,8 +18,8 @@ public class Main {
     //ambiente
 
     //registros
-    static Empleado registroPersonal;
-    static Empleado registroPersonalExterno;
+    private static Empleado registroPersonal;
+    private static Empleado registroPersonalExterno;
 
     //archivoPersonal
     private static File archivoPersonal;

--- a/src/main/java/com/frre/practica/isi/algoritmos/genericos/Main.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/genericos/Main.java
@@ -313,7 +313,7 @@ public class Main {
 }
 
 class JavaSourceFromString extends SimpleJavaFileObject {
-    final String code;
+    private final String code;
 
     JavaSourceFromString(String name, String code) {
         super(URI.create("string:///" + name.replace('.', '/') + Kind.SOURCE.extension), Kind.SOURCE);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat
