### PR TITLE
Cleanup - squid:S1118 - Utility classes should not have public constr…

### DIFF
--- a/src/main/java/com/frre/library/Generador.java
+++ b/src/main/java/com/frre/library/Generador.java
@@ -13,10 +13,14 @@ import java.util.Random;
  *
  * @author justomiguel
  */
-public class Generador {
+public final class Generador {
     
     private static Random rnd = new Random();
-    
+
+    private Generador() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instntiation");
+    }
+
     public static String generarApellidoAleatorio(){
         String appelidos = DataSource.apellidos;
         String[] split = appelidos.split(Constants.NEW_LINE);

--- a/src/main/java/com/frre/library/Ordenar.java
+++ b/src/main/java/com/frre/library/Ordenar.java
@@ -11,7 +11,11 @@ import org.apache.commons.lang3.ArrayUtils;
  *
  * @author justomiguel
  */
-public class Ordenar {
+public final class Ordenar {
+
+    private Ordenar() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static <T> T[] intercambio(T[] vector, boolean direction) {
         for (int i = 1; i < vector.length; i++) {

--- a/src/main/java/com/frre/library/Utils.java
+++ b/src/main/java/com/frre/library/Utils.java
@@ -19,8 +19,11 @@ import com.frre.library.data.Constants;
  *
  * @author Cleo
  */
-public class Utils {
-   
+public final class Utils {
+
+    private Utils() throws InstantiationException {
+     throw new InstantiationException("This class is not created for instantiation");   
+    }
 
     public static <T> T tranformAccordingType(Class<T> type, String string) {
 

--- a/src/main/java/com/frre/library/archivos/FuncionesDeArchivos.java
+++ b/src/main/java/com/frre/library/archivos/FuncionesDeArchivos.java
@@ -17,7 +17,7 @@ import static com.frre.library.data.Constants.*;
  *
  * @author developer
  */
-public class FuncionesDeArchivos {
+public final class FuncionesDeArchivos {
 
     private static HashMap<File, LectorArchivos> myArchs;
     private static HashMap<File, EscritorDeArchivos> myWrittenArchs;
@@ -25,6 +25,10 @@ public class FuncionesDeArchivos {
     static {
         myArchs = new HashMap<File, LectorArchivos>();
         myWrittenArchs = new HashMap<File, EscritorDeArchivos>();
+    }
+
+    private FuncionesDeArchivos() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
     }
 
     public static File abrir(String string) {

--- a/src/main/java/com/frre/library/archivos/GeneradorArchivos.java
+++ b/src/main/java/com/frre/library/archivos/GeneradorArchivos.java
@@ -15,7 +15,11 @@ import java.util.HashMap;
 /**
  * Created by jvargas on 8/20/15.
  */
-public class GeneradorArchivos {
+public final class GeneradorArchivos {
+
+    private GeneradorArchivos() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static <T> void generarArchivo(String nombreArchivo, T registro, int cantRegistros) {
         try{

--- a/src/main/java/com/frre/library/data/Constants.java
+++ b/src/main/java/com/frre/library/data/Constants.java
@@ -8,7 +8,7 @@ package com.frre.library.data;
  *
  * @author justomiguel
  */
-public class Constants {
+public final class Constants {
     
     public static final String DATE_SEPARATOR = "/";
     public static final String SPACE = " ";
@@ -30,4 +30,9 @@ public class Constants {
     public static final String NOT_SUPPORTED="Not supported yet.";
     public static final String COMMA = ",";
     public static final String DOT=".";
+
+    private Constants() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
+
 }

--- a/src/main/java/com/frre/library/data/DataSource.java
+++ b/src/main/java/com/frre/library/data/DataSource.java
@@ -8,7 +8,7 @@ package com.frre.library.data;
  *
  * @author justomiguel
  */
-public class DataSource {
+public final class DataSource {
     
     public static String apellidos = "Roma\n" +
 "Buzón\n" +
@@ -3361,5 +3361,9 @@ public class DataSource {
 "SANTA CRUZ                                        \n" +
 "TIERRA DEL FUEGO                                  \n" +
 "CIUDAD AUTONOMA BUENOS AIRES";
-    
+
+    private DataSource() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instntiation");
+    }
+
 }

--- a/src/main/java/com/frre/practica/isi/algoritmos/archivos/corte/Main.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/archivos/corte/Main.java
@@ -9,7 +9,7 @@ import java.io.File;
 /**
  * Created by jvargas on 8/20/15.
  */
-public class Main {
+public final class Main {
 
     //ambiente
 
@@ -28,6 +28,9 @@ public class Main {
     //archivo
     private static File archivo;
 
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     //algoritmo
     public static void main(String[] args){

--- a/src/main/java/com/frre/practica/isi/algoritmos/archivos/crear/Main.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/archivos/crear/Main.java
@@ -9,7 +9,7 @@ import java.io.File;
 /**
  * Created by jvargas on 8/20/15.
  */
-public class Main {
+public final class Main {
 
 
     //ambiente
@@ -17,6 +17,10 @@ public class Main {
     private static File archivo;
     //registro
     private static Usuario nuevoUsuario;
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     //algoritmo
     public static void main(String[] args){

--- a/src/main/java/com/frre/practica/isi/algoritmos/archivos/indexados/Main.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/archivos/indexados/Main.java
@@ -10,7 +10,7 @@ import java.io.File;
 /**
  * Created by jvargas on 8/20/15.
  */
-public class Main {
+public final class Main {
 
     //ambiente
 
@@ -33,6 +33,9 @@ public class Main {
     private static Bono bonos;
     private static File archivoIndexado;
 
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     //algoritmo
     public static void main(String[] args){

--- a/src/main/java/com/frre/practica/isi/algoritmos/archivos/lectura/Main.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/archivos/lectura/Main.java
@@ -8,7 +8,11 @@ package com.frre.practica.isi.algoritmos.archivos.lectura;
 /**
  * Created by jvargas on 8/20/15.
  */
-public class Main {
+public final class Main {
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
         //muestra de funciones con archivos

--- a/src/main/java/com/frre/practica/isi/algoritmos/archivos/mezcla/Main.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/archivos/mezcla/Main.java
@@ -12,7 +12,7 @@ import static com.frre.library.archivos.FuncionesDeArchivos.*;
 /**
  * Created by jvargas on 8/21/15.
  */
-public class Main {
+public final class Main {
 
 
     //ambiente
@@ -26,6 +26,9 @@ public class Main {
     private static File archivoPersonalExterno;
     private static File archivoFinal;
 
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     //algoritmo
     public static void main(String[] args){

--- a/src/main/java/com/frre/practica/isi/algoritmos/genericos/Main.java
+++ b/src/main/java/com/frre/practica/isi/algoritmos/genericos/Main.java
@@ -19,7 +19,7 @@ import java.util.Scanner;
 /**
  * Created by justo on 04/05/16.
  */
-public class Main {
+public final class Main {
 
     public static final String AMBIENTE = "Ambiente";
     public static final String ALGORITMO = "Algoritmo";
@@ -42,6 +42,10 @@ public class Main {
 
 
     public static HashMap<String, String> theVariables = new HashMap<String, String>();
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args) throws IOException {
         FileInputStream inputStream = null;

--- a/src/main/java/com/frre/practica/tsp/labii/Main.java
+++ b/src/main/java/com/frre/practica/tsp/labii/Main.java
@@ -9,7 +9,11 @@ import java.util.Set;
 /**
  * Created by jvargas on 8/21/15.
  */
-public class Main {
+public final class Main {
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
         Map<String, String> myMap = new HashMap<String, String>();

--- a/src/main/java/com/frre/practica/tsp/labii/RegistrationSystem.java
+++ b/src/main/java/com/frre/practica/tsp/labii/RegistrationSystem.java
@@ -6,7 +6,11 @@ import java.util.Scanner;
 /**
  * Created by jvargas on 8/21/15.
  */
-public class RegistrationSystem {
+public final class RegistrationSystem {
+
+    private RegistrationSystem() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
         Scanner scanner = new Scanner(System.in);

--- a/src/main/java/com/frre/practica/tsp/labii/files/Main.java
+++ b/src/main/java/com/frre/practica/tsp/labii/files/Main.java
@@ -5,7 +5,11 @@ import java.io.*;
 /**
  * Created by jvargas on 9/12/15.
  */
-public class Main {
+public final class Main {
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
         File dir = new File("./fotos");

--- a/src/main/java/com/frre/practica/tsp/labii/hilos/Main.java
+++ b/src/main/java/com/frre/practica/tsp/labii/hilos/Main.java
@@ -6,8 +6,11 @@ import java.util.ArrayList;
 /**
  * Created by jvargas on 8/28/15.
  */
-public class Main {
+public final class Main {
 
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args) throws Exception {
 

--- a/src/main/java/com/frre/practica/tsp/programacioni/archivos/crear/Main.java
+++ b/src/main/java/com/frre/practica/tsp/programacioni/archivos/crear/Main.java
@@ -11,7 +11,7 @@ import static com.frre.library.archivos.FuncionesDeArchivos.*;
 /**
  * Created by jvargas on 8/20/15.
  */
-public class Main {
+public final class Main {
 
 
     //ambiente
@@ -19,6 +19,10 @@ public class Main {
     private static File archivo;
     //registro
     private static Empleado nuevoUsuario;
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     //algoritmo
     public static void main(String[] args){

--- a/src/main/java/com/frre/practica/tsp/programacioni/archivos/lectura/Main.java
+++ b/src/main/java/com/frre/practica/tsp/programacioni/archivos/lectura/Main.java
@@ -7,7 +7,11 @@ import static com.frre.library.archivos.FuncionesDeArchivos.*;
 /**
  * Created by jvargas on 8/20/15.
  */
-public class Main {
+public final class Main {
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
         //muestra de funciones con archivos

--- a/src/main/java/com/frre/practica/tsp/programacioni/arreglos/Main.java
+++ b/src/main/java/com/frre/practica/tsp/programacioni/arreglos/Main.java
@@ -8,7 +8,11 @@ import java.util.Comparator;
 /**
  * Created by justo on 02/05/16.
  */
-public class Main {
+public final class Main {
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
         //se define un numero para el arreglo

--- a/src/main/java/com/frre/practica/tsp/programacioni/arreglos/busqueda/Main.java
+++ b/src/main/java/com/frre/practica/tsp/programacioni/arreglos/busqueda/Main.java
@@ -5,7 +5,11 @@ import java.util.Arrays;
 /**
  * Created by justo on 12/05/16.
  */
-public class Main {
+public final class Main {
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
         int[] arreglo = {7,51,1,12,34,1,23,45,67};

--- a/src/main/java/com/frre/practica/tsp/programacioni/arreglos/codeforces/Main.java
+++ b/src/main/java/com/frre/practica/tsp/programacioni/arreglos/codeforces/Main.java
@@ -3,7 +3,11 @@ package com.frre.practica.tsp.programacioni.arreglos.codeforces;
 /**
  * Created by justo on 19/05/16.
  */
-public class Main {
+public final class Main {
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
         

--- a/src/main/java/com/frre/practica/tsp/programacioni/arreglos/matrices/Main.java
+++ b/src/main/java/com/frre/practica/tsp/programacioni/arreglos/matrices/Main.java
@@ -3,8 +3,11 @@ package com.frre.practica.tsp.programacioni.arreglos.matrices;
 /**
  * Created by justo on 26/05/16.
  */
-public class Main {
+public final class Main {
 
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
         int[][] matriz = new int[4][4];

--- a/src/main/java/com/frre/practica/tsp/programacioni/arreglos/omegaup/BuscandoParejas.java
+++ b/src/main/java/com/frre/practica/tsp/programacioni/arreglos/omegaup/BuscandoParejas.java
@@ -9,7 +9,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Scanner;
 
-public class BuscandoParejas {
+public final class BuscandoParejas {
+    
+    private BuscandoParejas() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
 //ambiente
 

--- a/src/main/java/com/frre/practica/tsp/programacioni/arreglos/ordenamiento/Main.java
+++ b/src/main/java/com/frre/practica/tsp/programacioni/arreglos/ordenamiento/Main.java
@@ -5,7 +5,11 @@ import java.util.Arrays;
 /**
  * Created by justo on 12/05/16.
  */
-public class Main {
+public final class Main {
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
         int[] arreglo = {7,51,1,12,34};

--- a/src/main/java/com/frre/practica/tsp/programacionii/Main.java
+++ b/src/main/java/com/frre/practica/tsp/programacionii/Main.java
@@ -5,7 +5,11 @@ import com.frre.library.Generador;
 /**
  * Created by jvargas on 8/21/15.
  */
-public class Main {
+public final class Main {
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
 

--- a/src/main/java/com/frre/practica/tsp/programacionii/arboles/MainArboles.java
+++ b/src/main/java/com/frre/practica/tsp/programacionii/arboles/MainArboles.java
@@ -3,7 +3,11 @@ package com.frre.practica.tsp.programacionii.arboles;
 /**
  * Created by jvargas on 8/28/15.
  */
-public class MainArboles {
+public final class MainArboles {
+
+    private MainArboles() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
         NodoArbol<Integer> nodo4 = new NodoArbol<Integer>();

--- a/src/main/java/com/frre/practica/tsp/programacionii/ejerciciolistas/Main.java
+++ b/src/main/java/com/frre/practica/tsp/programacionii/ejerciciolistas/Main.java
@@ -5,7 +5,11 @@ import com.frre.library.Generador;
 /**
  * Created by jvargas on 8/28/15.
  */
-public class Main {
+public final class Main {
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void main(String[] args){
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
