### PR TITLE
Cleanup - squid:S1943 - Classes and methods that rely on the default …

### DIFF
--- a/src/main/java/com/frre/library/archivos/EscritorDeArchivos.java
+++ b/src/main/java/com/frre/library/archivos/EscritorDeArchivos.java
@@ -10,9 +10,11 @@ import com.frre.library.data.Constants;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
@@ -159,13 +161,13 @@ public class EscritorDeArchivos {
             }
 
             String contents = finalBuilder.toString();
-            FileWriter fw = null;
+            FileOutputStream fos = new FileOutputStream(myFile.getAbsoluteFile());
+            OutputStreamWriter outputStreamWriter = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+            BufferedWriter bw = new BufferedWriter(outputStreamWriter);
 
-            fw = new FileWriter(myFile.getAbsoluteFile());
-            BufferedWriter bw = new BufferedWriter(fw);
             bw.write(contents);
             bw.close();
-            fw.close();
+            fos.close();
         } catch (Exception ex) {
             Utils.handleException(ex);
         }

--- a/src/main/java/com/frre/library/archivos/FuncionesDeArchivos.java
+++ b/src/main/java/com/frre/library/archivos/FuncionesDeArchivos.java
@@ -4,8 +4,10 @@ import com.frre.library.Utils;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import static com.frre.library.data.Constants.*;
 
@@ -61,13 +63,14 @@ public final class FuncionesDeArchivos {
             }
 
             if (arch.exists()) {
-                FileWriter fw = null;
+                FileOutputStream fos;
                 try {
-                    fw = new FileWriter(arch.getAbsoluteFile());
-                    BufferedWriter bw = new BufferedWriter(fw);
+                    fos = new FileOutputStream(arch.getAbsoluteFile());
+                    OutputStreamWriter outputStreamWriter = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+                    BufferedWriter bw = new BufferedWriter(outputStreamWriter);
                     bw.write("");
                     bw.close();
-                    fw.close();
+                    fos.close();
                     EscritorDeArchivos esc = new EscritorDeArchivos(arch);
                     myWrittenArchs.put(arch, esc);
                 } catch (IOException ex) {

--- a/src/main/java/com/frre/library/archivos/LectorArchivos.java
+++ b/src/main/java/com/frre/library/archivos/LectorArchivos.java
@@ -10,9 +10,11 @@ import com.frre.library.Utils;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 /**
@@ -40,9 +42,9 @@ public class LectorArchivos<T> {
         theContents = (ArrayList<Object>) new ArrayList<T>();
         try {
             //use buffering, reading one line at a time
-            //FileReader always assumes default encoding is OK!
-            FileReader reader = new FileReader(myFile);
-            BufferedReader input = new BufferedReader(reader);
+            FileInputStream fis = new FileInputStream(myFile);
+            InputStreamReader inputStreamReader = new InputStreamReader(fis, StandardCharsets.UTF_8);
+            BufferedReader input = new BufferedReader(inputStreamReader);
             lines = new ArrayList<String>();
             try {
                 String line; //not declared within while loop
@@ -67,7 +69,7 @@ public class LectorArchivos<T> {
 
             } finally {
                 input.close();
-                reader.close();
+                fis.close();
             }
         } catch (Exception ex) {
             Utils.handleException(ex);

--- a/src/main/java/com/frre/practica/tsp/labii/RegistrationSystem.java
+++ b/src/main/java/com/frre/practica/tsp/labii/RegistrationSystem.java
@@ -13,7 +13,7 @@ public final class RegistrationSystem {
     }
 
     public static void main(String[] args){
-        Scanner scanner = new Scanner(System.in);
+        Scanner scanner = new Scanner(System.in, "UTF-8");
         int cantString = scanner.nextInt();
 
         HashMap<String, Integer> mapaValores = new HashMap<String, Integer>();

--- a/src/main/java/com/frre/practica/tsp/labii/hilos/ProcesoLargo.java
+++ b/src/main/java/com/frre/practica/tsp/labii/hilos/ProcesoLargo.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Created by jvargas on 8/28/15.
@@ -31,7 +32,7 @@ public class ProcesoLargo extends Thread {
            System.out.println("Response Code : " + responseCode);
 
            BufferedReader in = new BufferedReader(
-                   new InputStreamReader(con.getInputStream()));
+                   new InputStreamReader(con.getInputStream(), StandardCharsets.UTF_8));
            String inputLine;
            StringBuffer response = new StringBuffer();
 

--- a/src/main/java/com/frre/practica/tsp/programacioni/arreglos/omegaup/BuscandoParejas.java
+++ b/src/main/java/com/frre/practica/tsp/programacioni/arreglos/omegaup/BuscandoParejas.java
@@ -19,7 +19,7 @@ public final class BuscandoParejas {
 
     //algoritmo
     public static void main(String[] args){
-        Scanner sc = new Scanner(System.in);
+        Scanner sc = new Scanner(System.in, "UTF-8");
 
         int cantHombres = sc.nextInt();
         int cantMujeres = sc.nextInt();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat
